### PR TITLE
Pin pyproj

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        "%CONDA_INSTALL_LOCN%\python.exe" ff_ci_pr_build.py -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
     # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: linux_64
+- job: linux
   pool:
     vmImage: ubuntu-16.04
   timeoutInMinutes: 240
@@ -28,10 +28,12 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: osx_64
+- job: osx
   pool:
     vmImage: macOS-10.13
   timeoutInMinutes: 240
@@ -87,4 +87,6 @@ jobs:
       set -x -e
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -3,7 +3,7 @@
 # -*- mode: yaml -*-
 
 jobs:
-- job: win_64
+- job: win
   pool:
     vmImage: vs2017-win2016
   timeoutInMinutes: 240
@@ -77,20 +77,29 @@ jobs:
       displayName: conda-forge build setup
     
 
+    - script: |
+        rmdir C:\strawberry /s /q
+      continueOnError: true
+      displayName: remove strawberryperl
+
     # Special cased version setting some more things!
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe (vs2008)
-      env: {
-        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",
-      }
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
       condition: contains(variables['CONFIG'], 'vs2008')
 
     - script: |
-        conda.exe build recipe -m .ci_support\%CONFIG%.yaml --quiet
+        conda.exe build recipe -m .ci_support\%CONFIG%.yaml
       displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - use_proj_data.patch
 
 build:
-  number: 1001
+  number: 2
   skip: True  # [win and py2k]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - numpy 1.14.*  # [win]
     - geos
     - matplotlib >=1.0.0
-    - pyproj >=1.9.3
+    - pyproj >=1.9.3,<2
     - pyshp >=1.2.0
     - six
   run:
@@ -35,7 +35,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - geos
     - matplotlib >=1.0.0
-    - pyproj >=1.9.3
+    - pyproj >=1.9.3,<2
     - pyshp >=1.2.0
     - six
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/basemap-feedstock/issues/45

Not that conda may prefer older versions/build numbers b/c of the reduced version constraint in the pyproj requirements. In some cases we may need to re-pin and remove old packages, in other we may want to do a repo-patch. For basemap I'm confortable just removing the old packages.