### PR TITLE
Revert "Rebuild for geos390"

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,19 +11,19 @@ jobs:
       linux_64_numpy1.16python3.6.____cpython:
         CONFIG: linux_64_numpy1.16python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_64_numpy1.16python3.7.____cpython:
         CONFIG: linux_64_numpy1.16python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_64_numpy1.16python3.8.____cpython:
         CONFIG: linux_64_numpy1.16python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_64_numpy1.19python3.9.____cpython:
         CONFIG: linux_64_numpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '9'
+- '7'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '9'
+- '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-comp7
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '9'
+- '7'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '9'
+- '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-comp7
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '9'
+- '7'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '9'
+- '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-comp7
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '9'
+- '7'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,11 +11,11 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '9'
+- '7'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-comp7
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.19'
 pin_run_as_build:
@@ -31,7 +31,5 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image
 - - python
   - numpy

--- a/.ci_support/migrations/geos390.yaml
+++ b/.ci_support/migrations/geos390.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-geos:
-- 3.9.0
-migrator_ts: 1610648903.0543563

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '11'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '11'
+- '10'
 geos:
-- 3.9.0
+- 3.8.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '11'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '11'
+- '10'
 geos:
-- 3.9.0
+- 3.8.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '11'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '11'
+- '10'
 geos:
-- 3.9.0
+- 3.8.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '11'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +11,9 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '11'
+- '10'
 geos:
-- 3.9.0
+- 3.8.1
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 geos:
-- 3.9.0
+- 3.8.1
 numpy:
 - '1.19'
 pin_run_as_build:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,12 +45,8 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
-        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
-        if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
-        fi
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -68,8 +64,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - data.patch
 
 build:
-  number: 4
+  number: 3
   skip: True  # [win and py2k]
 
 requirements:


### PR DESCRIPTION
Reverts conda-forge/basemap-feedstock#73

It turns out we don't run enough tests and basemap does not work with geos 3.9.0. Reverting this one.
See #74 