### PR TITLE
Upgrade runtime requirements

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD-3-Clause license
-Copyright (c) 2015-2022, conda-forge contributors
+Copyright (c) 2015-2024, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.4.0" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 {% set data_version = "1.3.2" %}
 {% set data_build_number = 0 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - {{ pin_compatible('basemap-data', min_pin='x.x', max_pin='x.x') }}
         - {{ pin_compatible('numpy') }}
         - {{ pin_compatible('geos') }}
-        - matplotlib-base >=1.5,<3.8
+        - matplotlib-base >=1.5,<3.9
         - pyproj >=1.9.3,<3.7.0
         - pyshp >=1.2.0,<2.4.0
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,8 +56,8 @@ outputs:
       run:
         - python
         - {{ pin_compatible('basemap-data', min_pin='x.x', max_pin='x.x') }}
-        - {{ pin_compatible('numpy') }}
-        - {{ pin_compatible('geos') }}
+        - {{ pin_compatible('numpy', min_pin='x.x', max_pin='x.x') }}
+        - {{ pin_compatible('geos', min_pin='x.x.x', max_pin='x.x.x') }}
         - matplotlib-base >=1.5,<3.9
         - pyproj >=1.9.3,<3.7.0
         - pyshp >=1.2.0,<2.4.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
       build:
         - python                              # [build_platform != target_platform]
         - cross-python_{{ target_platform }}  # [build_platform != target_platform]
-        - cython >=0.29,<3.0                  # [build_platform != target_platform]
+        - cython >=0.29,<3.1                  # [build_platform != target_platform]
         - numpy >=1.21                        # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
@@ -49,7 +49,7 @@ outputs:
         - pip
         - setuptools
         - wheel
-        - cython >=0.29,<3.0
+        - cython >=0.29,<3.1
         - numpy >=1.21
         - geos
         - pyproj


### PR DESCRIPTION
Checklist:
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
It does not need to be re-rendered, because it was already done less than 30 minutes ago.

This PR updates the runtime requirements for `basemap` as appearing upstream. I noticed that the upper pin for `matplotlib-base` was not allowing to get the Python 3.12 migrator in the `basemap-feedstock` (see https://conda-forge.org/status/#python312):

```
linux_64_python3.12.____cpythonpython_implcpython: Could not solve for environment specs
The following packages are incompatible
├─ matplotlib-base >=1.5,<3.8  is installable with the potential options
│  ├─ matplotlib-base [2.1.2|2.2.3|2.2.4] would require
│  │  └─ python_abi * *_cp27mu, which can be installed;
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.4|3.1.1|3.1.2|3.1.3|3.2.0] would require
│  │  └─ python_abi * *_cp38, which can be installed;
│  ├─ matplotlib-base 2.2.5 would require
│  │  └─ python_abi 2.7.* *_cp27mu, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.3.4] would require
│  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.5.3] would require
│  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.7.3] would require
│  │  └─ python_abi 3.8.* *_cp38, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.3.2|...|3.7.3] would require
│  │  └─ python_abi 3.9.* *_cp39, which can be installed;
│  ├─ matplotlib-base [3.2.2|3.3.0|...|3.3.4] would require
│  │  └─ python_abi 3.6 *_pypy36_pp73, which can be installed;
│  ├─ matplotlib-base [3.3.3|3.3.4|...|3.5.2] would require
│  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
│  ├─ matplotlib-base [3.4.3|3.5.0|...|3.7.3] would require
│  │  └─ python_abi 3.10.* *_cp310, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.2] would require
│  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.3] would require
│  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
│  └─ matplotlib-base [3.6.1|3.6.2|...|3.7.3] would require
│     └─ python_abi 3.11.* *_cp311, which can be installed;
└─ python_abi 3.12.* *_cp312 is not installable because it conflicts with any installable versions previously reported.
osx_64_python3.12.____cpythonpython_implcpython: Could not solve for environment specs
The following packages are incompatible
├─ matplotlib-base >=1.5,<3.8  is installable with the potential options
│  ├─ matplotlib-base [2.1.2|2.2.3|2.2.4] would require
│  │  └─ python_abi * *_cp27m, which can be installed;
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.4|3.1.1|3.1.2|3.1.3|3.2.0] would require
│  │  └─ python_abi * *_cp38, which can be installed;
│  ├─ matplotlib-base 2.2.5 would require
│  │  └─ python_abi 2.7.* *_cp27m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.3.4] would require
│  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.5.3] would require
│  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.7.3] would require
│  │  └─ python_abi 3.8.* *_cp38, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.3.2|...|3.7.3] would require
│  │  └─ python_abi 3.9.* *_cp39, which can be installed;
│  ├─ matplotlib-base [3.2.2|3.3.0|...|3.3.4] would require
│  │  └─ python_abi 3.6 *_pypy36_pp73, which can be installed;
│  ├─ matplotlib-base [3.3.3|3.3.4|...|3.5.2] would require
│  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
│  ├─ matplotlib-base [3.4.3|3.5.0|...|3.7.3] would require
│  │  └─ python_abi 3.10.* *_cp310, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.2] would require
│  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.3] would require
│  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
│  └─ matplotlib-base [3.6.1|3.6.2|...|3.7.3] would require
│     └─ python_abi 3.11.* *_cp311, which can be installed;
└─ python_abi 3.12.* *_cp312 is not installable because it conflicts with any installable versions previously reported.
osx_arm64_python3.12.____cpython: Could not solve for environment specs
The following packages are incompatible
├─ matplotlib-base >=1.5,<3.8  is installable with the potential options
│  ├─ matplotlib-base [3.3.2|3.3.3|...|3.7.3] would require
│  │  └─ python_abi 3.8.* *_cp38, which can be installed;
│  ├─ matplotlib-base [3.3.2|3.3.3|...|3.7.3] would require
│  │  └─ python_abi 3.9.* *_cp39, which can be installed;
│  ├─ matplotlib-base [3.4.3|3.5.0|...|3.7.3] would require
│  │  └─ python_abi 3.10.* *_cp310, which can be installed;
│  └─ matplotlib-base [3.6.1|3.6.2|...|3.7.3] would require
│     └─ python_abi 3.11.* *_cp311, which can be installed;
└─ python_abi 3.12.* *_cp312 is not installable because it conflicts with any installable versions previously reported.
win_64_python3.12.____cpythonpython_implcpython: Could not solve for environment specs
The following packages are incompatible
├─ matplotlib-base >=1.5,<3.8  is installable with the potential options
│  ├─ matplotlib-base [2.1.2|2.2.3|2.2.4|2.2.5] would require
│  │  └─ vc 9.* , which does not exist (perhaps a missing channel);
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.1.2|2.2.3|...|3.2.0] would require
│  │  └─ python_abi * *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.4|3.1.1|3.1.2|3.1.3|3.2.0] would require
│  │  └─ python_abi * *_cp38, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.3.4] would require
│  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.5.3] would require
│  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.2.1|...|3.7.3] would require
│  │  └─ python_abi 3.8.* *_cp38, which can be installed;
│  ├─ matplotlib-base [2.2.5|3.3.2|...|3.7.3] would require
│  │  └─ python_abi 3.9.* *_cp39, which can be installed;
│  ├─ matplotlib-base [3.4.2|3.4.3|3.5.0|3.5.1|3.5.2] would require
│  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
│  ├─ matplotlib-base [3.4.3|3.5.0|...|3.7.3] would require
│  │  └─ python_abi 3.10.* *_cp310, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.2] would require
│  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
│  ├─ matplotlib-base [3.5.2|3.5.3|...|3.7.3] would require
│  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
│  └─ matplotlib-base [3.6.1|3.6.2|...|3.7.3] would require
│     └─ python_abi 3.11.* *_cp311, which can be installed;
└─ python_abi 3.12.* *_cp312 is not installable because it conflicts with any installable versions previously reported.
```